### PR TITLE
Fix Stats and BinTestCases after adding "Built at"

### DIFF
--- a/lib/Stats.js
+++ b/lib/Stats.js
@@ -500,12 +500,17 @@ class Stats {
 			newline();
 		}
 		if(typeof obj.time === "number") {
-			colors.normal("Built at: ");
-			colors.bold(new Date(obj.builtAt));
-			newline();
 			colors.normal("Time: ");
 			colors.bold(obj.time);
 			colors.normal("ms");
+			newline();
+		}
+		if(typeof obj.builtAt === "number") {
+			const now = (new Date()).toString().split(" ");
+			colors.normal("Built at: ");
+			colors.normal(`${now[0]} ${now[1]} ${now[2]} ${now[3]} `);
+			colors.bold(now[4]);
+			colors.normal(now[6] ? ` ${now[5]} ${now[6]}` : ` ${now[5]}`);
 			newline();
 		}
 		if(obj.publicPath) {

--- a/test/Stats.test.js
+++ b/test/Stats.test.js
@@ -74,14 +74,20 @@ describe("Stats", () => {
 				if(!hasColorSetting) {
 					actual = actual
 						.replace(/\u001b\[[0-9;]*m/g, "")
-						.replace(/[0-9]+(\s?ms)/g, "X$1");
+						.replace(/[0-9]+(\s?ms)/g, "X$1")
+						.replace(
+							/[A-z]{3} [A-z]{3} \d\d \d{4} \d\d:\d\d:\d\d GMT[+-]\d{4}( \(\w{3,4}\))?/g,
+							"Thu Jan 01 1970 00:00:00 GMT");
 				} else {
 					actual = actual
 						.replace(/\u001b\[1m\u001b\[([0-9;]*)m/g, "<CLR=$1,BOLD>")
 						.replace(/\u001b\[1m/g, "<CLR=BOLD>")
 						.replace(/\u001b\[39m\u001b\[22m/g, "</CLR>")
 						.replace(/\u001b\[([0-9;]*)m/g, "<CLR=$1>")
-						.replace(/[0-9]+(<\/CLR>)?(\s?ms)/g, "X$1$2");
+						.replace(/[0-9]+(<\/CLR>)?(\s?ms)/g, "X$1$2")
+						.replace(
+							/[A-z]{3} [A-z]{3} \d\d \d{4} (<CLR=BOLD>)?\d\d:\d\d:\d\d(<\/CLR>)? GMT[+-]\d{4}( \(\w{3,4}\))?/g,
+							"Thu Jan 01 1970 $100:00:00$2 GMT");
 				}
 
 				actual = actual

--- a/test/binCases/entry/multi-file/test.js
+++ b/test/binCases/entry/multi-file/test.js
@@ -4,10 +4,10 @@ module.exports = function testAssertions(code, stdout, stderr) {
 	code.should.be.exactly(0);
 
 	stdout.should.be.ok();
-	stdout[4].should.containEql("null.js");
-	stdout[5].should.match(/a\.js.*\{0\}/);
-	stdout[6].should.match(/index\.js.*\{0\}/);
-	stdout[7].should.match(/multi.*index\.js.*a\.js/); // should have multi-file entry
+	stdout[5].should.containEql("null.js");
+	stdout[6].should.match(/a\.js.*\{0\}/);
+	stdout[7].should.match(/index\.js.*\{0\}/);
+	stdout[8].should.match(/multi.*index\.js.*a\.js/); // should have multi-file entry
 	stderr.should.be.empty();
 };
 

--- a/test/binCases/entry/named-entry/test.js
+++ b/test/binCases/entry/named-entry/test.js
@@ -4,10 +4,10 @@ module.exports = function testAssertions(code, stdout, stderr) {
 	code.should.be.exactly(0);
 
 	stdout.should.be.ok();
-	stdout[4].should.containEql("null.js");
-	stdout[5].should.containEql("foo.js"); // named entry from --entry foo=./a.js
-	stdout[6].should.match(/a\.js.*\{1\}/);
-	stdout[7].should.match(/index\.js.*\{0\}/);
+	stdout[5].should.containEql("null.js");
+	stdout[6].should.containEql("foo.js"); // named entry from --entry foo=./a.js
+	stdout[7].should.match(/a\.js.*\{1\}/);
+	stdout[8].should.match(/index\.js.*\{0\}/);
 	stderr.should.be.empty();
 };
 

--- a/test/binCases/entry/non-hyphenated-args/test.js
+++ b/test/binCases/entry/non-hyphenated-args/test.js
@@ -4,10 +4,10 @@ module.exports = function testAssertions(code, stdout, stderr) {
 	code.should.be.exactly(0);
 
 	stdout.should.be.ok();
-	stdout[4].should.containEql("null.js");
-	stdout[5].should.containEql("main.js"); // non-hyphenated arg ./a.js should create chunk "main"
-	stdout[6].should.match(/a\.js.*\{1\}/); // a.js should be in chunk 1
-	stdout[7].should.match(/index\.js.*\{0\}/); // index.js should be in chunk 0
+	stdout[5].should.containEql("null.js");
+	stdout[6].should.containEql("main.js"); // non-hyphenated arg ./a.js should create chunk "main"
+	stdout[7].should.match(/a\.js.*\{1\}/); // a.js should be in chunk 1
+	stdout[8].should.match(/index\.js.*\{0\}/); // index.js should be in chunk 0
 	stderr.should.be.empty();
 };
 

--- a/test/binCases/plugins/uglifyjsplugin-empty-args/test.js
+++ b/test/binCases/plugins/uglifyjsplugin-empty-args/test.js
@@ -4,7 +4,7 @@ module.exports = function testAssertions(code, stdout, stderr) {
 	code.should.be.exactly(0);
 
 	stdout.should.be.ok();
-	stdout[4].should.containEql("bytes"); // without uglifyjs it's multiple kBs
+	stdout[5].should.containEql("bytes"); // without uglifyjs it's multiple kBs
 
 	stderr.should.be.empty();
 };

--- a/test/binCases/stats/single-config/test.js
+++ b/test/binCases/stats/single-config/test.js
@@ -7,10 +7,11 @@ module.exports = function testAssertions(code, stdout, stderr) {
 	stdout[0].should.containEql("Hash: ");
 	stdout[1].should.containEql("Version: ");
 	stdout[2].should.containEql("Time: ");
-	stdout[4].should.containEql("\u001b[1m\u001b[32mnull.js\u001b[39m\u001b[22m");
-	stdout[5].should.not.containEql("./index.js");
-	stdout[5].should.not.containEql("[built]");
-	stdout[5].should.containEql("1 hidden module");
+	stdout[3].should.containEql("Built at: ");
+	stdout[5].should.containEql("\u001b[1m\u001b[32mnull.js\u001b[39m\u001b[22m");
+	stdout[6].should.not.containEql("./index.js");
+	stdout[6].should.not.containEql("[built]");
+	stdout[6].should.containEql("1 hidden module");
 
 	stderr.should.be.empty();
 };

--- a/test/statsCases/aggressive-splitting-entry/expected.txt
+++ b/test/statsCases/aggressive-splitting-entry/expected.txt
@@ -1,5 +1,6 @@
 Hash: c4756fe25e35ccb187f7
 Time: Xms
+Built at: Thu Jan 01 1970 00:00:00 GMT
                   Asset       Size  Chunks             Chunk Names
 48c8b1dae03a37363ec8.js    4.37 kB       1  [emitted]  
 002fc3bb6fc14459f8e8.js    2.23 kB       2  [emitted]  

--- a/test/statsCases/aggressive-splitting-on-demand/expected.txt
+++ b/test/statsCases/aggressive-splitting-on-demand/expected.txt
@@ -1,5 +1,6 @@
 Hash: 57bbddba5221b9ac4a33
 Time: Xms
+Built at: Thu Jan 01 1970 00:00:00 GMT
                   Asset       Size  Chunks             Chunk Names
 fc930a2adf8206ea2dc5.js    1.94 kB       0  [emitted]  
 cd45585186d59208602b.js    1.96 kB       1  [emitted]  

--- a/test/statsCases/chunks/expected.txt
+++ b/test/statsCases/chunks/expected.txt
@@ -1,5 +1,6 @@
 Hash: 6ab76347dbbefb99c3c5
 Time: Xms
+Built at: Thu Jan 01 1970 00:00:00 GMT
       Asset       Size  Chunks             Chunk Names
 0.bundle.js  238 bytes       0  [emitted]  
 1.bundle.js  108 bytes       1  [emitted]  

--- a/test/statsCases/color-disabled/expected.txt
+++ b/test/statsCases/color-disabled/expected.txt
@@ -1,5 +1,6 @@
 Hash: 6c781fe6bf412ba6435b
 Time: Xms
+Built at: Thu Jan 01 1970 00:00:00 GMT
   Asset     Size  Chunks             Chunk Names
 main.js  2.63 kB       0  [emitted]  main
 chunk    {0} main.js (main) 0 bytes [entry] [rendered]

--- a/test/statsCases/color-enabled-custom/expected.txt
+++ b/test/statsCases/color-enabled-custom/expected.txt
@@ -1,5 +1,6 @@
 Hash: <CLR=BOLD>6c781fe6bf412ba6435b</CLR>
 Time: <CLR=BOLD>X</CLR>ms
+Built at: Thu Jan 01 1970 <CLR=BOLD>00:00:00</CLR> GMT
   <CLR=BOLD>Asset</CLR>     <CLR=BOLD>Size</CLR>  <CLR=BOLD>Chunks</CLR>  <CLR=39,BOLD><CLR=22>           <CLR=39,BOLD><CLR=22><CLR=BOLD>Chunk Names</CLR>
 <CLR=32>main.js</CLR>  2.63 kB       <CLR=BOLD>0</CLR>  <CLR=32>[emitted]</CLR>  main
 chunk    {<CLR=33>0</CLR>} <CLR=32>main.js</CLR> (main) 0 bytes<CLR=33> [entry]</CLR><CLR=32> [rendered]</CLR>

--- a/test/statsCases/color-enabled/expected.txt
+++ b/test/statsCases/color-enabled/expected.txt
@@ -1,5 +1,6 @@
 Hash: <CLR=BOLD>6c781fe6bf412ba6435b</CLR>
 Time: <CLR=BOLD>X</CLR>ms
+Built at: Thu Jan 01 1970 <CLR=BOLD>00:00:00</CLR> GMT
   <CLR=BOLD>Asset</CLR>     <CLR=BOLD>Size</CLR>  <CLR=BOLD>Chunks</CLR>  <CLR=39,BOLD><CLR=22>           <CLR=39,BOLD><CLR=22><CLR=BOLD>Chunk Names</CLR>
 <CLR=32,BOLD>main.js</CLR>  2.63 kB       <CLR=BOLD>0</CLR>  <CLR=32,BOLD>[emitted]</CLR>  main
 chunk    {<CLR=33,BOLD>0</CLR>} <CLR=32,BOLD>main.js</CLR> (main) 0 bytes<CLR=33,BOLD> [entry]</CLR><CLR=32,BOLD> [rendered]</CLR>

--- a/test/statsCases/commons-chunk-min-size-0/expected.txt
+++ b/test/statsCases/commons-chunk-min-size-0/expected.txt
@@ -1,5 +1,6 @@
 Hash: dc6038bec87a57d1a45e
 Time: Xms
+Built at: Thu Jan 01 1970 00:00:00 GMT
       Asset      Size  Chunks             Chunk Names
  entry-1.js  25 bytes       0  [emitted]  entry-1
 vendor-1.js   6.93 kB       1  [emitted]  vendor-1

--- a/test/statsCases/commons-chunk-min-size-Infinity/expected.txt
+++ b/test/statsCases/commons-chunk-min-size-Infinity/expected.txt
@@ -1,5 +1,6 @@
 Hash: 9c0d5be5c7febb314e7a
 Time: Xms
+Built at: Thu Jan 01 1970 00:00:00 GMT
       Asset     Size  Chunks             Chunk Names
  entry-1.js  3.27 kB       0  [emitted]  entry-1
 vendor-1.js  3.02 kB       1  [emitted]  vendor-1

--- a/test/statsCases/commons-plugin-issue-4980/expected.txt
+++ b/test/statsCases/commons-plugin-issue-4980/expected.txt
@@ -2,6 +2,7 @@ Hash: 7d3a56317b2e339b1d822897fe6052020598632c
 Child
     Hash: 7d3a56317b2e339b1d82
     Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
                              Asset       Size  Chunks             Chunk Names
                             app.js    1.27 kB       0  [emitted]  app
     vendor.bd2b4219dfda1a951495.js  443 bytes       1  [emitted]  vendor
@@ -16,6 +17,7 @@ Child
 Child
     Hash: 2897fe6052020598632c
     Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
                              Asset       Size  Chunks             Chunk Names
                             app.js    1.32 kB       0  [emitted]  app
     vendor.bd2b4219dfda1a951495.js  443 bytes       1  [emitted]  vendor

--- a/test/statsCases/define-plugin/expected.txt
+++ b/test/statsCases/define-plugin/expected.txt
@@ -2,6 +2,7 @@ Hash: 052d0451a89cb963e4d3eb3ff8e5a88b9234d04f
 Child
     Hash: 052d0451a89cb963e4d3
     Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
       Asset     Size  Chunks             Chunk Names
     main.js  2.68 kB       0  [emitted]  main
     chunk    {0} main.js (main) 24 bytes [entry] [rendered]
@@ -9,6 +10,7 @@ Child
 Child
     Hash: eb3ff8e5a88b9234d04f
     Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
       Asset     Size  Chunks             Chunk Names
     main.js  2.68 kB       0  [emitted]  main
     chunk    {0} main.js (main) 24 bytes [entry] [rendered]

--- a/test/statsCases/exclude-with-loader/expected.txt
+++ b/test/statsCases/exclude-with-loader/expected.txt
@@ -1,5 +1,6 @@
 Hash: 7ab067a6a9fc61623ae0
 Time: Xms
+Built at: Thu Jan 01 1970 00:00:00 GMT
     Asset    Size  Chunks             Chunk Names
 bundle.js  2.9 kB       0  [emitted]  main
 chunk    {0} bundle.js (main) 132 bytes [entry] [rendered]

--- a/test/statsCases/external/expected.txt
+++ b/test/statsCases/external/expected.txt
@@ -1,5 +1,6 @@
 Hash: 86950abf8dcf924d9cc1
 Time: Xms
+Built at: Thu Jan 01 1970 00:00:00 GMT
   Asset     Size  Chunks             Chunk Names
 main.js  2.77 kB       0  [emitted]  main
 chunk    {0} main.js (main) 59 bytes [entry] [rendered]

--- a/test/statsCases/filter-warnings/expected.txt
+++ b/test/statsCases/filter-warnings/expected.txt
@@ -2,6 +2,7 @@ Hash: e4d2b189bb205589ee1ee4d2b189bb205589ee1ee4d2b189bb205589ee1ee4d2b189bb2055
 Child
     Hash: e4d2b189bb205589ee1e
     Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset     Size  Chunks             Chunk Names
     bundle.js  2.17 kB       0  [emitted]  main
     chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
@@ -21,61 +22,49 @@ Child
 Child
     Hash: e4d2b189bb205589ee1e
     Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset     Size  Chunks             Chunk Names
     bundle.js  2.17 kB       0  [emitted]  main
     chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
 Child
     Hash: e4d2b189bb205589ee1e
     Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset     Size  Chunks             Chunk Names
     bundle.js  2.17 kB       0  [emitted]  main
     chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
 Child
     Hash: e4d2b189bb205589ee1e
     Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset     Size  Chunks             Chunk Names
     bundle.js  2.17 kB       0  [emitted]  main
     chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
 Child
     Hash: e4d2b189bb205589ee1e
     Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset     Size  Chunks             Chunk Names
     bundle.js  2.17 kB       0  [emitted]  main
     chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
 Child
     Hash: e4d2b189bb205589ee1e
     Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset     Size  Chunks             Chunk Names
     bundle.js  2.17 kB       0  [emitted]  main
     chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
 Child
     Hash: e4d2b189bb205589ee1e
     Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset     Size  Chunks             Chunk Names
     bundle.js  2.17 kB       0  [emitted]  main
     chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
 Child
     Hash: e4d2b189bb205589ee1e
     Time: Xms
-        Asset     Size  Chunks             Chunk Names
-    bundle.js  2.17 kB       0  [emitted]  main
-    chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
-    
-    WARNING in bundle.js from UglifyJs
-    Dropping unused function someRemoteUnUsedFunction1 [./a.js:3,0]
-    Dropping unused function someRemoteUnUsedFunction2 [./a.js:4,0]
-    Dropping unused function someRemoteUnUsedFunction3 [./a.js:5,0]
-    Dropping unused function someRemoteUnUsedFunction4 [./a.js:6,0]
-    Dropping unused function someRemoteUnUsedFunction5 [./a.js:7,0]
-    Dropping side-effect-free statement [./index.js:6,0]
-    Dropping unused function someUnUsedFunction1 [./index.js:8,0]
-    Dropping unused function someUnUsedFunction2 [./index.js:9,0]
-    Dropping unused function someUnUsedFunction3 [./index.js:10,0]
-    Dropping unused function someUnUsedFunction4 [./index.js:11,0]
-    Dropping unused function someUnUsedFunction5 [./index.js:12,0]
-Child
-    Hash: e4d2b189bb205589ee1e
-    Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset     Size  Chunks             Chunk Names
     bundle.js  2.17 kB       0  [emitted]  main
     chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
@@ -95,6 +84,7 @@ Child
 Child
     Hash: e4d2b189bb205589ee1e
     Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset     Size  Chunks             Chunk Names
     bundle.js  2.17 kB       0  [emitted]  main
     chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
@@ -114,6 +104,7 @@ Child
 Child
     Hash: e4d2b189bb205589ee1e
     Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset     Size  Chunks             Chunk Names
     bundle.js  2.17 kB       0  [emitted]  main
     chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
@@ -133,6 +124,7 @@ Child
 Child
     Hash: e4d2b189bb205589ee1e
     Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset     Size  Chunks             Chunk Names
     bundle.js  2.17 kB       0  [emitted]  main
     chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
@@ -152,6 +144,27 @@ Child
 Child
     Hash: e4d2b189bb205589ee1e
     Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
+        Asset     Size  Chunks             Chunk Names
+    bundle.js  2.17 kB       0  [emitted]  main
+    chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
+    
+    WARNING in bundle.js from UglifyJs
+    Dropping unused function someRemoteUnUsedFunction1 [./a.js:3,0]
+    Dropping unused function someRemoteUnUsedFunction2 [./a.js:4,0]
+    Dropping unused function someRemoteUnUsedFunction3 [./a.js:5,0]
+    Dropping unused function someRemoteUnUsedFunction4 [./a.js:6,0]
+    Dropping unused function someRemoteUnUsedFunction5 [./a.js:7,0]
+    Dropping side-effect-free statement [./index.js:6,0]
+    Dropping unused function someUnUsedFunction1 [./index.js:8,0]
+    Dropping unused function someUnUsedFunction2 [./index.js:9,0]
+    Dropping unused function someUnUsedFunction3 [./index.js:10,0]
+    Dropping unused function someUnUsedFunction4 [./index.js:11,0]
+    Dropping unused function someUnUsedFunction5 [./index.js:12,0]
+Child
+    Hash: e4d2b189bb205589ee1e
+    Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset     Size  Chunks             Chunk Names
     bundle.js  2.17 kB       0  [emitted]  main
     chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]

--- a/test/statsCases/limit-chunk-count-plugin/expected.txt
+++ b/test/statsCases/limit-chunk-count-plugin/expected.txt
@@ -2,6 +2,7 @@ Hash: 7785ad0c3d45a94a3238a8178dd1adacd47a6b70043f3d1f8be496acf7a6e0df24380874d1
 Child
     Hash: 7785ad0c3d45a94a3238
     Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
         Asset     Size  Chunks             Chunk Names
     bundle.js  3.56 kB       0  [emitted]  main
     chunk    {0} bundle.js (main) 191 bytes [entry] [rendered]
@@ -14,6 +15,7 @@ Child
 Child
     Hash: a8178dd1adacd47a6b70
     Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
           Asset       Size  Chunks             Chunk Names
     0.bundle.js  592 bytes       0  [emitted]  
       bundle.js    6.29 kB       1  [emitted]  main
@@ -28,6 +30,7 @@ Child
 Child
     Hash: 043f3d1f8be496acf7a6
     Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
           Asset       Size  Chunks             Chunk Names
     0.bundle.js  445 bytes       0  [emitted]  
     1.bundle.js  204 bytes       1  [emitted]  
@@ -44,6 +47,7 @@ Child
 Child
     Hash: e0df24380874d11a123a
     Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
           Asset       Size  Chunks             Chunk Names
     0.bundle.js  204 bytes       0  [emitted]  
     1.bundle.js  195 bytes       1  [emitted]  

--- a/test/statsCases/max-modules-default/expected.txt
+++ b/test/statsCases/max-modules-default/expected.txt
@@ -1,5 +1,6 @@
 Hash: 8f4b66734cb63e0581be
 Time: Xms
+Built at: Thu Jan 01 1970 00:00:00 GMT
   Asset     Size  Chunks             Chunk Names
 main.js  5.95 kB       0  [emitted]  main
 chunk    {0} main.js (main) 1.18 kB [entry] [rendered]

--- a/test/statsCases/max-modules/expected.txt
+++ b/test/statsCases/max-modules/expected.txt
@@ -1,5 +1,6 @@
 Hash: 8f4b66734cb63e0581be
 Time: Xms
+Built at: Thu Jan 01 1970 00:00:00 GMT
   Asset     Size  Chunks             Chunk Names
 main.js  5.95 kB       0  [emitted]  main
 chunk    {0} main.js (main) 1.18 kB [entry] [rendered]

--- a/test/statsCases/module-trace-disabled-in-error/expected.txt
+++ b/test/statsCases/module-trace-disabled-in-error/expected.txt
@@ -1,5 +1,6 @@
 Hash: 6e950f2e83663cb6e9a6
 Time: Xms
+Built at: Thu Jan 01 1970 00:00:00 GMT
   Asset     Size  Chunks             Chunk Names
 main.js  2.81 kB       0  [emitted]  main
 chunk    {0} main.js (main) 25 bytes [entry] [rendered]

--- a/test/statsCases/module-trace-enabled-in-error/expected.txt
+++ b/test/statsCases/module-trace-enabled-in-error/expected.txt
@@ -1,5 +1,6 @@
 Hash: 6e950f2e83663cb6e9a6
 Time: Xms
+Built at: Thu Jan 01 1970 00:00:00 GMT
   Asset     Size  Chunks             Chunk Names
 main.js  2.81 kB       0  [emitted]  main
 chunk    {0} main.js (main) 25 bytes [entry] [rendered]

--- a/test/statsCases/named-chunks-plugin-async/expected.txt
+++ b/test/statsCases/named-chunks-plugin-async/expected.txt
@@ -1,5 +1,6 @@
 Hash: ad8adb01e611de794006
 Time: Xms
+Built at: Thu Jan 01 1970 00:00:00 GMT
                      Asset       Size                   Chunks             Chunk Names
 chunk-containing-__a_js.js  266 bytes  chunk-containing-__a_js  [emitted]  
 chunk-containing-__b_js.js  123 bytes  chunk-containing-__b_js  [emitted]  

--- a/test/statsCases/named-chunks-plugin/expected.txt
+++ b/test/statsCases/named-chunks-plugin/expected.txt
@@ -1,5 +1,6 @@
 Hash: ac63e5be974bcdfea3a3
 Time: Xms
+Built at: Thu Jan 01 1970 00:00:00 GMT
       Asset       Size    Chunks             Chunk Names
    entry.js  345 bytes     entry  [emitted]  entry
 manifest.js    5.95 kB  manifest  [emitted]  manifest

--- a/test/statsCases/optimize-chunks/expected.txt
+++ b/test/statsCases/optimize-chunks/expected.txt
@@ -1,5 +1,6 @@
 Hash: 999ae28af33cdfa6ec93
 Time: Xms
+Built at: Thu Jan 01 1970 00:00:00 GMT
   Asset       Size  Chunks             Chunk Names
    0.js  231 bytes       0  [emitted]  cir1
    1.js  218 bytes    1, 2  [emitted]  abd

--- a/test/statsCases/performance-disabled/expected.txt
+++ b/test/statsCases/performance-disabled/expected.txt
@@ -1,4 +1,5 @@
 Time: <CLR=BOLD>X</CLR>ms
+Built at: Thu Jan 01 1970 <CLR=BOLD>00:00:00</CLR> GMT
   <CLR=BOLD>Asset</CLR>       <CLR=BOLD>Size</CLR>  <CLR=BOLD>Chunks</CLR>  <CLR=39,BOLD><CLR=22>           <CLR=39,BOLD><CLR=22><CLR=BOLD>Chunk Names</CLR>
    <CLR=32,BOLD>0.js</CLR>  238 bytes       <CLR=BOLD>0</CLR>  <CLR=32,BOLD>[emitted]</CLR>  
    <CLR=32,BOLD>1.js</CLR>  108 bytes       <CLR=BOLD>1</CLR>  <CLR=32,BOLD>[emitted]</CLR>  

--- a/test/statsCases/performance-error/expected.txt
+++ b/test/statsCases/performance-error/expected.txt
@@ -1,4 +1,5 @@
 Time: <CLR=BOLD>X</CLR>ms
+Built at: Thu Jan 01 1970 <CLR=BOLD>00:00:00</CLR> GMT
   <CLR=BOLD>Asset</CLR>       <CLR=BOLD>Size</CLR>  <CLR=BOLD>Chunks</CLR>  <CLR=39,BOLD><CLR=22>           <CLR=39,BOLD><CLR=22>       <CLR=BOLD>Chunk Names</CLR>
    <CLR=32,BOLD>0.js</CLR>  238 bytes       <CLR=BOLD>0</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
    <CLR=32,BOLD>1.js</CLR>  108 bytes       <CLR=BOLD>1</CLR>  <CLR=32,BOLD>[emitted]</CLR>         

--- a/test/statsCases/performance-no-async-chunks-shown/expected.txt
+++ b/test/statsCases/performance-no-async-chunks-shown/expected.txt
@@ -1,4 +1,5 @@
 Time: <CLR=BOLD>X</CLR>ms
+Built at: Thu Jan 01 1970 <CLR=BOLD>00:00:00</CLR> GMT
   <CLR=BOLD>Asset</CLR>     <CLR=BOLD>Size</CLR>  <CLR=BOLD>Chunks</CLR>  <CLR=39,BOLD><CLR=22>           <CLR=39,BOLD><CLR=22>       <CLR=BOLD>Chunk Names</CLR>
  <CLR=32,BOLD>sec.js</CLR>  2.98 kB       <CLR=BOLD>0</CLR>  <CLR=32,BOLD>[emitted]</CLR>         sec
 <CLR=33,BOLD>main.js</CLR>   <CLR=33,BOLD>303 kB</CLR>       <CLR=BOLD>1</CLR>  <CLR=32,BOLD>[emitted]</CLR>  <CLR=33,BOLD>[big]</CLR>  main

--- a/test/statsCases/performance-no-hints/expected.txt
+++ b/test/statsCases/performance-no-hints/expected.txt
@@ -1,4 +1,5 @@
 Time: <CLR=BOLD>X</CLR>ms
+Built at: Thu Jan 01 1970 <CLR=BOLD>00:00:00</CLR> GMT
   <CLR=BOLD>Asset</CLR>       <CLR=BOLD>Size</CLR>  <CLR=BOLD>Chunks</CLR>  <CLR=39,BOLD><CLR=22>           <CLR=39,BOLD><CLR=22>       <CLR=BOLD>Chunk Names</CLR>
    <CLR=32,BOLD>0.js</CLR>  238 bytes       <CLR=BOLD>0</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
    <CLR=32,BOLD>1.js</CLR>  108 bytes       <CLR=BOLD>1</CLR>  <CLR=32,BOLD>[emitted]</CLR>         

--- a/test/statsCases/performance-oversize-limit-error/expected.txt
+++ b/test/statsCases/performance-oversize-limit-error/expected.txt
@@ -1,4 +1,5 @@
 Time: <CLR=BOLD>X</CLR>ms
+Built at: Thu Jan 01 1970 <CLR=BOLD>00:00:00</CLR> GMT
   <CLR=BOLD>Asset</CLR>    <CLR=BOLD>Size</CLR>  <CLR=BOLD>Chunks</CLR>  <CLR=39,BOLD><CLR=22>           <CLR=39,BOLD><CLR=22>       <CLR=BOLD>Chunk Names</CLR>
  <CLR=33,BOLD>sec.js</CLR>  <CLR=33,BOLD>303 kB</CLR>       <CLR=BOLD>0</CLR>  <CLR=32,BOLD>[emitted]</CLR>  <CLR=33,BOLD>[big]</CLR>  sec
 <CLR=33,BOLD>main.js</CLR>  <CLR=33,BOLD>303 kB</CLR>       <CLR=BOLD>1</CLR>  <CLR=32,BOLD>[emitted]</CLR>  <CLR=33,BOLD>[big]</CLR>  main

--- a/test/statsCases/preset-normal-performance-ensure-filter-sourcemaps/expected.txt
+++ b/test/statsCases/preset-normal-performance-ensure-filter-sourcemaps/expected.txt
@@ -1,4 +1,5 @@
 Time: <CLR=BOLD>X</CLR>ms
+Built at: Thu Jan 01 1970 <CLR=BOLD>00:00:00</CLR> GMT
       <CLR=BOLD>Asset</CLR>       <CLR=BOLD>Size</CLR>  <CLR=BOLD>Chunks</CLR>  <CLR=39,BOLD><CLR=22>           <CLR=39,BOLD><CLR=22>       <CLR=BOLD>Chunk Names</CLR>
        <CLR=32,BOLD>0.js</CLR>  268 bytes       <CLR=BOLD>0</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
        <CLR=32,BOLD>1.js</CLR>  138 bytes       <CLR=BOLD>1</CLR>  <CLR=32,BOLD>[emitted]</CLR>         

--- a/test/statsCases/preset-normal-performance/expected.txt
+++ b/test/statsCases/preset-normal-performance/expected.txt
@@ -1,4 +1,5 @@
 Time: <CLR=BOLD>X</CLR>ms
+Built at: Thu Jan 01 1970 <CLR=BOLD>00:00:00</CLR> GMT
   <CLR=BOLD>Asset</CLR>       <CLR=BOLD>Size</CLR>  <CLR=BOLD>Chunks</CLR>  <CLR=39,BOLD><CLR=22>           <CLR=39,BOLD><CLR=22>       <CLR=BOLD>Chunk Names</CLR>
    <CLR=32,BOLD>0.js</CLR>  238 bytes       <CLR=BOLD>0</CLR>  <CLR=32,BOLD>[emitted]</CLR>         
    <CLR=32,BOLD>1.js</CLR>  108 bytes       <CLR=BOLD>1</CLR>  <CLR=32,BOLD>[emitted]</CLR>         

--- a/test/statsCases/preset-normal/expected.txt
+++ b/test/statsCases/preset-normal/expected.txt
@@ -1,5 +1,6 @@
 Hash: c5a6856b43905ae12f17
 Time: Xms
+Built at: Thu Jan 01 1970 00:00:00 GMT
 chunk    {0} 0.js 54 bytes {3} [rendered]
 chunk    {1} 1.js 22 bytes {3} [rendered]
 chunk    {2} 2.js 44 bytes {0} [rendered]

--- a/test/statsCases/preset-verbose/expected.txt
+++ b/test/statsCases/preset-verbose/expected.txt
@@ -1,5 +1,6 @@
 Hash: c5a6856b43905ae12f17
 Time: Xms
+Built at: Thu Jan 01 1970 00:00:00 GMT
   Asset       Size  Chunks             Chunk Names
    0.js  238 bytes       0  [emitted]  
    1.js  108 bytes       1  [emitted]  

--- a/test/statsCases/resolve-plugin-context/expected.txt
+++ b/test/statsCases/resolve-plugin-context/expected.txt
@@ -1,5 +1,6 @@
 Hash: 94e1d97f3e1cf37e753f
 Time: Xms
+Built at: Thu Jan 01 1970 00:00:00 GMT
     Asset     Size  Chunks             Chunk Names
 bundle.js  3.04 kB       0  [emitted]  main
 chunk    {0} bundle.js (main) 80 bytes [entry] [rendered]

--- a/test/statsCases/reverse-sort-modules/expected.txt
+++ b/test/statsCases/reverse-sort-modules/expected.txt
@@ -1,5 +1,6 @@
 Hash: 8f4b66734cb63e0581be
 Time: Xms
+Built at: Thu Jan 01 1970 00:00:00 GMT
   Asset     Size  Chunks             Chunk Names
 main.js  5.95 kB       0  [emitted]  main
 chunk    {0} main.js (main) 1.18 kB [entry] [rendered]

--- a/test/statsCases/separate-css-bundle/expected.txt
+++ b/test/statsCases/separate-css-bundle/expected.txt
@@ -2,6 +2,7 @@ Hash: 0be4035986816982617a1139e89514abc13454ce
 Child
     Hash: 0be4035986816982617a
     Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
                                    Asset      Size  Chunks             Chunk Names
                  c7ab11336573e45dc51e.js   2.78 kB       0  [emitted]  main
     c815cf440254d4f3bba4e7041db00a28.css  26 bytes       0  [emitted]  main
@@ -15,6 +16,7 @@ Child
 Child
     Hash: 1139e89514abc13454ce
     Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
                                    Asset      Size  Chunks             Chunk Names
                  c7ab11336573e45dc51e.js   2.78 kB       0  [emitted]  main
     a3f385680aef7a9bb2a517699532cc34.css  28 bytes       0  [emitted]  main

--- a/test/statsCases/simple-more-info/expected.txt
+++ b/test/statsCases/simple-more-info/expected.txt
@@ -1,5 +1,6 @@
 Hash: 0bd4f09244f0e8c60354
 Time: Xms
+Built at: Thu Jan 01 1970 00:00:00 GMT
     Asset     Size  Chunks             Chunk Names
 bundle.js  2.63 kB       0  [emitted]  main
 chunk    {0} bundle.js (main) 0 bytes [entry] [rendered]

--- a/test/statsCases/simple/expected.txt
+++ b/test/statsCases/simple/expected.txt
@@ -1,5 +1,6 @@
 Hash: 0bd4f09244f0e8c60354
 Time: Xms
+Built at: Thu Jan 01 1970 00:00:00 GMT
     Asset     Size  Chunks             Chunk Names
 bundle.js  2.63 kB       0  [emitted]  main
 chunk    {0} bundle.js (main) 0 bytes [entry] [rendered]

--- a/test/statsCases/tree-shaking/expected.txt
+++ b/test/statsCases/tree-shaking/expected.txt
@@ -1,5 +1,6 @@
 Hash: 347e6d2384c1a580ac4d
 Time: Xms
+Built at: Thu Jan 01 1970 00:00:00 GMT
     Asset     Size  Chunks             Chunk Names
 bundle.js  7.49 kB       0  [emitted]  main
 chunk    {0} bundle.js (main) 588 bytes [entry] [rendered]

--- a/test/statsCases/warnings-uglifyjs/expected.txt
+++ b/test/statsCases/warnings-uglifyjs/expected.txt
@@ -1,5 +1,6 @@
 Hash: 4beee256fa6b8f69eae8
 Time: Xms
+Built at: Thu Jan 01 1970 00:00:00 GMT
     Asset     Size  Chunks             Chunk Names
 bundle.js  2.17 kB       0  [emitted]  main
 chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]


### PR DESCRIPTION
In order to pass the tests, a similar
test replacement as with the millisecond values
needs to happen.

For the "Built at" stat all dates are replaces with
Thu Jan 01 1970 00:00:00 GMT.

Related to issue #5305

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

**If relevant, link to documentation update:**

<!-- Link PR from webpack/webpack.js.org here, or N/A -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
