### PR TITLE
Update binCases/statsCases after merge from origin

### DIFF
--- a/test/binCases/entry/multi-file/test.js
+++ b/test/binCases/entry/multi-file/test.js
@@ -5,9 +5,9 @@ module.exports = function testAssertions(code, stdout, stderr) {
 
 	stdout.should.be.ok();
 	stdout[5].should.containEql("null.js");
-	stdout[6].should.match(/a\.js.*\{0\}/);
+	stdout[6].should.match(/multi.*index\.js.*a\.js/); // should have multi-file entry
 	stdout[7].should.match(/index\.js.*\{0\}/);
-	stdout[8].should.match(/multi.*index\.js.*a\.js/); // should have multi-file entry
+	stdout[8].should.match(/a\.js.*\{0\}/);
 	stderr.should.be.empty();
 };
 

--- a/test/binCases/entry/non-hyphenated-args/test.js
+++ b/test/binCases/entry/non-hyphenated-args/test.js
@@ -6,8 +6,8 @@ module.exports = function testAssertions(code, stdout, stderr) {
 	stdout.should.be.ok();
 	stdout[5].should.containEql("null.js");
 	stdout[6].should.containEql("main.js"); // non-hyphenated arg ./a.js should create chunk "main"
-	stdout[7].should.match(/a\.js.*\{1\}/); // a.js should be in chunk 1
-	stdout[8].should.match(/index\.js.*\{0\}/); // index.js should be in chunk 0
+	stdout[7].should.match(/index\.js.*\{0\}/); // index.js should be in chunk 0
+	stdout[8].should.match(/a\.js.*\{1\}/); // a.js should be in chunk 1
 	stderr.should.be.empty();
 };
 

--- a/test/binCases/stats/single-config/test.js
+++ b/test/binCases/stats/single-config/test.js
@@ -11,6 +11,6 @@ module.exports = function testAssertions(code, stdout, stderr) {
 	stdout[5].should.containEql("\u001b[1m\u001b[32mnull.js\u001b[39m\u001b[22m");
 	stdout[6].should.not.containEql("./index.js");
 	stdout[6].should.not.containEql("[built]");
-	stdout[6].should.containEql("1 hidden module");
+	stdout[7].should.containEql("1 module");
 	stderr.should.be.empty();
 };

--- a/test/statsCases/exclude-with-loader/expected.txt
+++ b/test/statsCases/exclude-with-loader/expected.txt
@@ -1,9 +1,8 @@
 Hash: 9a949e8727d0583cb1c4
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
-    Asset    Size  Chunks             Chunk Names
-bundle.js  2.9 kB       0  [emitted]  main
-chunk    {0} bundle.js (main) 132 bytes [entry] [rendered]
-    [0] (webpack)/test/statsCases/exclude-with-loader/a.txt 43 bytes {0} [built]
-    [2] (webpack)/test/statsCases/exclude-with-loader/index.js 46 bytes {0} [built]
-     + 1 hidden modules
+    Asset     Size  Chunks             Chunk Names
+bundle.js  2.74 kB       0  [emitted]  main
+   [0] (webpack)/test/statsCases/exclude-with-loader/index.js 46 bytes {0} [built]
+   [1] (webpack)/test/statsCases/exclude-with-loader/a.txt 43 bytes {0} [built]
+    + 1 hidden module

--- a/test/statsCases/filter-warnings/expected.txt
+++ b/test/statsCases/filter-warnings/expected.txt
@@ -1,183 +1,170 @@
-Hash: e4d2b189bb205589ee1ee4d2b189bb205589ee1ee4d2b189bb205589ee1ee4d2b189bb205589ee1ee4d2b189bb205589ee1ee4d2b189bb205589ee1ee4d2b189bb205589ee1ee4d2b189bb205589ee1ee4d2b189bb205589ee1ee4d2b189bb205589ee1ee4d2b189bb205589ee1ee4d2b189bb205589ee1ee4d2b189bb205589ee1e
+Hash: 3cc7bf529a74b021bee53cc7bf529a74b021bee53cc7bf529a74b021bee53cc7bf529a74b021bee53cc7bf529a74b021bee53cc7bf529a74b021bee53cc7bf529a74b021bee53cc7bf529a74b021bee53cc7bf529a74b021bee53cc7bf529a74b021bee53cc7bf529a74b021bee53cc7bf529a74b021bee53cc7bf529a74b021bee5
 Child
-    Hash: e4d2b189bb205589ee1e
+    Hash: 3cc7bf529a74b021bee5
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
-        Asset     Size  Chunks             Chunk Names
-    bundle.js  2.17 kB       0  [emitted]  main
-    chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
+        Asset    Size  Chunks             Chunk Names
+    bundle.js  2.1 kB       0  [emitted]  main
     
     WARNING in bundle.js from UglifyJs
-    Dropping unused function someRemoteUnUsedFunction1 [./a.js:3,0]
-    Dropping unused function someRemoteUnUsedFunction2 [./a.js:4,0]
-    Dropping unused function someRemoteUnUsedFunction3 [./a.js:5,0]
-    Dropping unused function someRemoteUnUsedFunction4 [./a.js:6,0]
-    Dropping unused function someRemoteUnUsedFunction5 [./a.js:7,0]
     Dropping side-effect-free statement [./index.js:6,0]
     Dropping unused function someUnUsedFunction1 [./index.js:8,0]
     Dropping unused function someUnUsedFunction2 [./index.js:9,0]
     Dropping unused function someUnUsedFunction3 [./index.js:10,0]
     Dropping unused function someUnUsedFunction4 [./index.js:11,0]
     Dropping unused function someUnUsedFunction5 [./index.js:12,0]
-Child
-    Hash: e4d2b189bb205589ee1e
-    Time: Xms
-    Built at: Thu Jan 01 1970 00:00:00 GMT
-        Asset     Size  Chunks             Chunk Names
-    bundle.js  2.17 kB       0  [emitted]  main
-    chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
-Child
-    Hash: e4d2b189bb205589ee1e
-    Time: Xms
-    Built at: Thu Jan 01 1970 00:00:00 GMT
-        Asset     Size  Chunks             Chunk Names
-    bundle.js  2.17 kB       0  [emitted]  main
-    chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
-Child
-    Hash: e4d2b189bb205589ee1e
-    Time: Xms
-    Built at: Thu Jan 01 1970 00:00:00 GMT
-        Asset     Size  Chunks             Chunk Names
-    bundle.js  2.17 kB       0  [emitted]  main
-    chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
-Child
-    Hash: e4d2b189bb205589ee1e
-    Time: Xms
-    Built at: Thu Jan 01 1970 00:00:00 GMT
-        Asset     Size  Chunks             Chunk Names
-    bundle.js  2.17 kB       0  [emitted]  main
-    chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
-Child
-    Hash: e4d2b189bb205589ee1e
-    Time: Xms
-    Built at: Thu Jan 01 1970 00:00:00 GMT
-        Asset     Size  Chunks             Chunk Names
-    bundle.js  2.17 kB       0  [emitted]  main
-    chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
-Child
-    Hash: e4d2b189bb205589ee1e
-    Time: Xms
-    Built at: Thu Jan 01 1970 00:00:00 GMT
-        Asset     Size  Chunks             Chunk Names
-    bundle.js  2.17 kB       0  [emitted]  main
-    chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
-Child
-    Hash: e4d2b189bb205589ee1e
-    Time: Xms
-    Built at: Thu Jan 01 1970 00:00:00 GMT
-        Asset     Size  Chunks             Chunk Names
-    bundle.js  2.17 kB       0  [emitted]  main
-    chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
-    
-    WARNING in bundle.js from UglifyJs
     Dropping unused function someRemoteUnUsedFunction1 [./a.js:3,0]
     Dropping unused function someRemoteUnUsedFunction2 [./a.js:4,0]
     Dropping unused function someRemoteUnUsedFunction3 [./a.js:5,0]
     Dropping unused function someRemoteUnUsedFunction4 [./a.js:6,0]
     Dropping unused function someRemoteUnUsedFunction5 [./a.js:7,0]
+Child
+    Hash: 3cc7bf529a74b021bee5
+    Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
+        Asset    Size  Chunks             Chunk Names
+    bundle.js  2.1 kB       0  [emitted]  main
+Child
+    Hash: 3cc7bf529a74b021bee5
+    Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
+        Asset    Size  Chunks             Chunk Names
+    bundle.js  2.1 kB       0  [emitted]  main
+Child
+    Hash: 3cc7bf529a74b021bee5
+    Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
+        Asset    Size  Chunks             Chunk Names
+    bundle.js  2.1 kB       0  [emitted]  main
+Child
+    Hash: 3cc7bf529a74b021bee5
+    Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
+        Asset    Size  Chunks             Chunk Names
+    bundle.js  2.1 kB       0  [emitted]  main
+Child
+    Hash: 3cc7bf529a74b021bee5
+    Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
+        Asset    Size  Chunks             Chunk Names
+    bundle.js  2.1 kB       0  [emitted]  main
+Child
+    Hash: 3cc7bf529a74b021bee5
+    Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
+        Asset    Size  Chunks             Chunk Names
+    bundle.js  2.1 kB       0  [emitted]  main
+Child
+    Hash: 3cc7bf529a74b021bee5
+    Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
+        Asset    Size  Chunks             Chunk Names
+    bundle.js  2.1 kB       0  [emitted]  main
+    
+    WARNING in bundle.js from UglifyJs
     Dropping side-effect-free statement [./index.js:6,0]
     Dropping unused function someUnUsedFunction1 [./index.js:8,0]
     Dropping unused function someUnUsedFunction2 [./index.js:9,0]
     Dropping unused function someUnUsedFunction3 [./index.js:10,0]
     Dropping unused function someUnUsedFunction4 [./index.js:11,0]
     Dropping unused function someUnUsedFunction5 [./index.js:12,0]
-Child
-    Hash: e4d2b189bb205589ee1e
-    Time: Xms
-    Built at: Thu Jan 01 1970 00:00:00 GMT
-        Asset     Size  Chunks             Chunk Names
-    bundle.js  2.17 kB       0  [emitted]  main
-    chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
-    
-    WARNING in bundle.js from UglifyJs
     Dropping unused function someRemoteUnUsedFunction1 [./a.js:3,0]
     Dropping unused function someRemoteUnUsedFunction2 [./a.js:4,0]
     Dropping unused function someRemoteUnUsedFunction3 [./a.js:5,0]
     Dropping unused function someRemoteUnUsedFunction4 [./a.js:6,0]
     Dropping unused function someRemoteUnUsedFunction5 [./a.js:7,0]
+Child
+    Hash: 3cc7bf529a74b021bee5
+    Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
+        Asset    Size  Chunks             Chunk Names
+    bundle.js  2.1 kB       0  [emitted]  main
+    
+    WARNING in bundle.js from UglifyJs
     Dropping side-effect-free statement [./index.js:6,0]
     Dropping unused function someUnUsedFunction1 [./index.js:8,0]
     Dropping unused function someUnUsedFunction2 [./index.js:9,0]
     Dropping unused function someUnUsedFunction3 [./index.js:10,0]
     Dropping unused function someUnUsedFunction4 [./index.js:11,0]
     Dropping unused function someUnUsedFunction5 [./index.js:12,0]
-Child
-    Hash: e4d2b189bb205589ee1e
-    Time: Xms
-    Built at: Thu Jan 01 1970 00:00:00 GMT
-        Asset     Size  Chunks             Chunk Names
-    bundle.js  2.17 kB       0  [emitted]  main
-    chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
-    
-    WARNING in bundle.js from UglifyJs
     Dropping unused function someRemoteUnUsedFunction1 [./a.js:3,0]
     Dropping unused function someRemoteUnUsedFunction2 [./a.js:4,0]
     Dropping unused function someRemoteUnUsedFunction3 [./a.js:5,0]
     Dropping unused function someRemoteUnUsedFunction4 [./a.js:6,0]
     Dropping unused function someRemoteUnUsedFunction5 [./a.js:7,0]
+Child
+    Hash: 3cc7bf529a74b021bee5
+    Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
+        Asset    Size  Chunks             Chunk Names
+    bundle.js  2.1 kB       0  [emitted]  main
+    
+    WARNING in bundle.js from UglifyJs
     Dropping side-effect-free statement [./index.js:6,0]
     Dropping unused function someUnUsedFunction1 [./index.js:8,0]
     Dropping unused function someUnUsedFunction2 [./index.js:9,0]
     Dropping unused function someUnUsedFunction3 [./index.js:10,0]
     Dropping unused function someUnUsedFunction4 [./index.js:11,0]
     Dropping unused function someUnUsedFunction5 [./index.js:12,0]
-Child
-    Hash: e4d2b189bb205589ee1e
-    Time: Xms
-    Built at: Thu Jan 01 1970 00:00:00 GMT
-        Asset     Size  Chunks             Chunk Names
-    bundle.js  2.17 kB       0  [emitted]  main
-    chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
-    
-    WARNING in bundle.js from UglifyJs
     Dropping unused function someRemoteUnUsedFunction1 [./a.js:3,0]
     Dropping unused function someRemoteUnUsedFunction2 [./a.js:4,0]
     Dropping unused function someRemoteUnUsedFunction3 [./a.js:5,0]
     Dropping unused function someRemoteUnUsedFunction4 [./a.js:6,0]
     Dropping unused function someRemoteUnUsedFunction5 [./a.js:7,0]
+Child
+    Hash: 3cc7bf529a74b021bee5
+    Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
+        Asset    Size  Chunks             Chunk Names
+    bundle.js  2.1 kB       0  [emitted]  main
+    
+    WARNING in bundle.js from UglifyJs
     Dropping side-effect-free statement [./index.js:6,0]
     Dropping unused function someUnUsedFunction1 [./index.js:8,0]
     Dropping unused function someUnUsedFunction2 [./index.js:9,0]
     Dropping unused function someUnUsedFunction3 [./index.js:10,0]
     Dropping unused function someUnUsedFunction4 [./index.js:11,0]
     Dropping unused function someUnUsedFunction5 [./index.js:12,0]
-Child
-    Hash: e4d2b189bb205589ee1e
-    Time: Xms
-    Built at: Thu Jan 01 1970 00:00:00 GMT
-        Asset     Size  Chunks             Chunk Names
-    bundle.js  2.17 kB       0  [emitted]  main
-    chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
-    
-    WARNING in bundle.js from UglifyJs
     Dropping unused function someRemoteUnUsedFunction1 [./a.js:3,0]
     Dropping unused function someRemoteUnUsedFunction2 [./a.js:4,0]
     Dropping unused function someRemoteUnUsedFunction3 [./a.js:5,0]
     Dropping unused function someRemoteUnUsedFunction4 [./a.js:6,0]
     Dropping unused function someRemoteUnUsedFunction5 [./a.js:7,0]
+Child
+    Hash: 3cc7bf529a74b021bee5
+    Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
+        Asset    Size  Chunks             Chunk Names
+    bundle.js  2.1 kB       0  [emitted]  main
+    
+    WARNING in bundle.js from UglifyJs
     Dropping side-effect-free statement [./index.js:6,0]
     Dropping unused function someUnUsedFunction1 [./index.js:8,0]
     Dropping unused function someUnUsedFunction2 [./index.js:9,0]
     Dropping unused function someUnUsedFunction3 [./index.js:10,0]
     Dropping unused function someUnUsedFunction4 [./index.js:11,0]
     Dropping unused function someUnUsedFunction5 [./index.js:12,0]
-Child
-    Hash: e4d2b189bb205589ee1e
-    Time: Xms
-    Built at: Thu Jan 01 1970 00:00:00 GMT
-        Asset     Size  Chunks             Chunk Names
-    bundle.js  2.17 kB       0  [emitted]  main
-    chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
-    
-    WARNING in bundle.js from UglifyJs
     Dropping unused function someRemoteUnUsedFunction1 [./a.js:3,0]
     Dropping unused function someRemoteUnUsedFunction2 [./a.js:4,0]
     Dropping unused function someRemoteUnUsedFunction3 [./a.js:5,0]
     Dropping unused function someRemoteUnUsedFunction4 [./a.js:6,0]
     Dropping unused function someRemoteUnUsedFunction5 [./a.js:7,0]
+Child
+    Hash: 3cc7bf529a74b021bee5
+    Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
+        Asset    Size  Chunks             Chunk Names
+    bundle.js  2.1 kB       0  [emitted]  main
+    
+    WARNING in bundle.js from UglifyJs
     Dropping side-effect-free statement [./index.js:6,0]
     Dropping unused function someUnUsedFunction1 [./index.js:8,0]
     Dropping unused function someUnUsedFunction2 [./index.js:9,0]
     Dropping unused function someUnUsedFunction3 [./index.js:10,0]
     Dropping unused function someUnUsedFunction4 [./index.js:11,0]
     Dropping unused function someUnUsedFunction5 [./index.js:12,0]
+    Dropping unused function someRemoteUnUsedFunction1 [./a.js:3,0]
+    Dropping unused function someRemoteUnUsedFunction2 [./a.js:4,0]
+    Dropping unused function someRemoteUnUsedFunction3 [./a.js:5,0]
+    Dropping unused function someRemoteUnUsedFunction4 [./a.js:6,0]
+    Dropping unused function someRemoteUnUsedFunction5 [./a.js:7,0]

--- a/test/statsCases/limit-chunk-count-plugin/expected.txt
+++ b/test/statsCases/limit-chunk-count-plugin/expected.txt
@@ -1,65 +1,65 @@
-Hash: 7785ad0c3d45a94a3238a8178dd1adacd47a6b70043f3d1f8be496acf7a6e0df24380874d11a123a
+Hash: e0c3e190f6cf11c37f15b34fa5f72acbbc9cbd9a404c277a8869b8a6a62e5c32ec6fc2ff40a3b587
 Child
-    Hash: 7785ad0c3d45a94a3238
+    Hash: e0c3e190f6cf11c37f15
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
-        Asset     Size  Chunks             Chunk Names
-    bundle.js  3.56 kB       0  [emitted]  main
+        Asset    Size  Chunks             Chunk Names
+    bundle.js  3.4 kB       0  [emitted]  main
     chunk    {0} bundle.js (main) 191 bytes [entry] [rendered]
-        [0] (webpack)/test/statsCases/limit-chunk-count-plugin/a.js 22 bytes {0} [built]
-        [1] (webpack)/test/statsCases/limit-chunk-count-plugin/b.js 22 bytes {0} [built]
-        [2] (webpack)/test/statsCases/limit-chunk-count-plugin/c.js 30 bytes {0} [built]
-        [3] (webpack)/test/statsCases/limit-chunk-count-plugin/d.js 22 bytes {0} [built]
-        [4] (webpack)/test/statsCases/limit-chunk-count-plugin/e.js 22 bytes {0} [built]
-        [5] (webpack)/test/statsCases/limit-chunk-count-plugin/index.js 73 bytes {0} [built]
+        [0] (webpack)/test/statsCases/limit-chunk-count-plugin/index.js 73 bytes {0} [built]
+        [1] (webpack)/test/statsCases/limit-chunk-count-plugin/a.js 22 bytes {0} [built]
+        [2] (webpack)/test/statsCases/limit-chunk-count-plugin/b.js 22 bytes {0} [built]
+        [3] (webpack)/test/statsCases/limit-chunk-count-plugin/c.js 30 bytes {0} [built]
+        [4] (webpack)/test/statsCases/limit-chunk-count-plugin/d.js 22 bytes {0} [built]
+        [5] (webpack)/test/statsCases/limit-chunk-count-plugin/e.js 22 bytes {0} [built]
 Child
-    Hash: a8178dd1adacd47a6b70
+    Hash: b34fa5f72acbbc9cbd9a
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
           Asset       Size  Chunks             Chunk Names
-    0.bundle.js  592 bytes       0  [emitted]  
-      bundle.js    6.29 kB       1  [emitted]  main
+    0.bundle.js  601 bytes       0  [emitted]  
+      bundle.js    6.12 kB       1  [emitted]  main
     chunk    {0} 0.bundle.js 118 bytes {1} [rendered]
-        [0] (webpack)/test/statsCases/limit-chunk-count-plugin/a.js 22 bytes {0} [built]
-        [1] (webpack)/test/statsCases/limit-chunk-count-plugin/b.js 22 bytes {0} [built]
-        [2] (webpack)/test/statsCases/limit-chunk-count-plugin/c.js 30 bytes {0} [built]
-        [3] (webpack)/test/statsCases/limit-chunk-count-plugin/d.js 22 bytes {0} [built]
-        [4] (webpack)/test/statsCases/limit-chunk-count-plugin/e.js 22 bytes {0} [built]
+        [1] (webpack)/test/statsCases/limit-chunk-count-plugin/a.js 22 bytes {0} [built]
+        [2] (webpack)/test/statsCases/limit-chunk-count-plugin/b.js 22 bytes {0} [built]
+        [3] (webpack)/test/statsCases/limit-chunk-count-plugin/c.js 30 bytes {0} [built]
+        [4] (webpack)/test/statsCases/limit-chunk-count-plugin/d.js 22 bytes {0} [built]
+        [5] (webpack)/test/statsCases/limit-chunk-count-plugin/e.js 22 bytes {0} [built]
     chunk    {1} bundle.js (main) 73 bytes [entry] [rendered]
-        [5] (webpack)/test/statsCases/limit-chunk-count-plugin/index.js 73 bytes {1} [built]
+        [0] (webpack)/test/statsCases/limit-chunk-count-plugin/index.js 73 bytes {1} [built]
 Child
-    Hash: 043f3d1f8be496acf7a6
+    Hash: 404c277a8869b8a6a62e
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
           Asset       Size  Chunks             Chunk Names
-    0.bundle.js  445 bytes       0  [emitted]  
-    1.bundle.js  204 bytes       1  [emitted]  
-      bundle.js    6.28 kB       2  [emitted]  main
+    0.bundle.js  454 bytes       0  [emitted]  
+    1.bundle.js  182 bytes       1  [emitted]  
+      bundle.js    6.11 kB       2  [emitted]  main
     chunk    {0} 0.bundle.js 74 bytes {2} [rendered]
-        [0] (webpack)/test/statsCases/limit-chunk-count-plugin/a.js 22 bytes {0} [built]
-        [2] (webpack)/test/statsCases/limit-chunk-count-plugin/c.js 30 bytes {0} [built]
-        [3] (webpack)/test/statsCases/limit-chunk-count-plugin/d.js 22 bytes {0} [built]
+        [1] (webpack)/test/statsCases/limit-chunk-count-plugin/a.js 22 bytes {0} [built]
+        [3] (webpack)/test/statsCases/limit-chunk-count-plugin/c.js 30 bytes {0} [built]
+        [4] (webpack)/test/statsCases/limit-chunk-count-plugin/d.js 22 bytes {0} [built]
     chunk    {1} 1.bundle.js 44 bytes {0} {2} [rendered]
-        [1] (webpack)/test/statsCases/limit-chunk-count-plugin/b.js 22 bytes {1} [built]
-        [4] (webpack)/test/statsCases/limit-chunk-count-plugin/e.js 22 bytes {1} [built]
+        [2] (webpack)/test/statsCases/limit-chunk-count-plugin/b.js 22 bytes {1} [built]
+        [5] (webpack)/test/statsCases/limit-chunk-count-plugin/e.js 22 bytes {1} [built]
     chunk    {2} bundle.js (main) 73 bytes [entry] [rendered]
-        [5] (webpack)/test/statsCases/limit-chunk-count-plugin/index.js 73 bytes {2} [built]
+        [0] (webpack)/test/statsCases/limit-chunk-count-plugin/index.js 73 bytes {2} [built]
 Child
-    Hash: e0df24380874d11a123a
+    Hash: 5c32ec6fc2ff40a3b587
     Time: Xms
     Built at: Thu Jan 01 1970 00:00:00 GMT
           Asset       Size  Chunks             Chunk Names
-    0.bundle.js  204 bytes       0  [emitted]  
-    1.bundle.js  195 bytes       1  [emitted]  
+    0.bundle.js  182 bytes       0  [emitted]  
+    1.bundle.js  204 bytes       1  [emitted]  
     2.bundle.js  283 bytes       2  [emitted]  
-      bundle.js    6.26 kB       3  [emitted]  main
+      bundle.js     6.1 kB       3  [emitted]  main
     chunk    {0} 0.bundle.js 44 bytes {2} {3} [rendered]
-        [1] (webpack)/test/statsCases/limit-chunk-count-plugin/b.js 22 bytes {0} [built]
-        [4] (webpack)/test/statsCases/limit-chunk-count-plugin/e.js 22 bytes {0} [built]
+        [2] (webpack)/test/statsCases/limit-chunk-count-plugin/b.js 22 bytes {0} [built]
+        [5] (webpack)/test/statsCases/limit-chunk-count-plugin/e.js 22 bytes {0} [built]
     chunk    {1} 1.bundle.js 44 bytes {2} {3} [rendered]
-        [0] (webpack)/test/statsCases/limit-chunk-count-plugin/a.js 22 bytes {1} [built]
-        [3] (webpack)/test/statsCases/limit-chunk-count-plugin/d.js 22 bytes {1} [built]
+        [1] (webpack)/test/statsCases/limit-chunk-count-plugin/a.js 22 bytes {1} [built]
+        [4] (webpack)/test/statsCases/limit-chunk-count-plugin/d.js 22 bytes {1} [built]
     chunk    {2} 2.bundle.js 30 bytes {3} [rendered]
-        [2] (webpack)/test/statsCases/limit-chunk-count-plugin/c.js 30 bytes {2} [built]
+        [3] (webpack)/test/statsCases/limit-chunk-count-plugin/c.js 30 bytes {2} [built]
     chunk    {3} bundle.js (main) 73 bytes [entry] [rendered]
-        [5] (webpack)/test/statsCases/limit-chunk-count-plugin/index.js 73 bytes {3} [built]
+        [0] (webpack)/test/statsCases/limit-chunk-count-plugin/index.js 73 bytes {3} [built]

--- a/test/statsCases/preset-detailed/expected.txt
+++ b/test/statsCases/preset-detailed/expected.txt
@@ -1,5 +1,6 @@
 Hash: fd034b07589b0d56afb3
 Time: Xms
+Built at: Thu Jan 01 1970 00:00:00 GMT
   Asset       Size  Chunks             Chunk Names
    0.js  238 bytes       0  [emitted]  
    1.js  102 bytes       1  [emitted]  

--- a/test/statsCases/preset-normal/expected.txt
+++ b/test/statsCases/preset-normal/expected.txt
@@ -1,7 +1,14 @@
-Hash: c5a6856b43905ae12f17
+Hash: fd034b07589b0d56afb3
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
-chunk    {0} 0.js 54 bytes {3} [rendered]
-chunk    {1} 1.js 22 bytes {3} [rendered]
-chunk    {2} 2.js 44 bytes {0} [rendered]
-chunk    {3} main.js (main) 73 bytes [entry] [rendered]
+  Asset       Size  Chunks             Chunk Names
+   0.js  238 bytes       0  [emitted]  
+   1.js  102 bytes       1  [emitted]  
+   2.js  182 bytes       2  [emitted]  
+main.js     6.1 kB       3  [emitted]  main
+   [0] (webpack)/test/statsCases/preset-normal/index.js 51 bytes {3} [built]
+   [1] (webpack)/test/statsCases/preset-normal/a.js 22 bytes {3} [built]
+   [2] (webpack)/test/statsCases/preset-normal/b.js 22 bytes {1} [built]
+   [3] (webpack)/test/statsCases/preset-normal/c.js 54 bytes {0} [built]
+   [4] (webpack)/test/statsCases/preset-normal/d.js 22 bytes {2} [built]
+   [5] (webpack)/test/statsCases/preset-normal/e.js 22 bytes {2} [built]

--- a/test/statsCases/scope-hoisting-multi/expected.txt
+++ b/test/statsCases/scope-hoisting-multi/expected.txt
@@ -2,6 +2,7 @@ Hash: 731069e082cf620521ce637b388d1abe7f9228e5
 Child
     Hash: 731069e082cf620521ce
     Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
        [0] (webpack)/test/statsCases/scope-hoisting-multi/common_lazy_shared.js 25 bytes {0} {1} {2} [built]
        [1] (webpack)/test/statsCases/scope-hoisting-multi/vendor.js 25 bytes {5} [built]
        [2] (webpack)/test/statsCases/scope-hoisting-multi/common.js 37 bytes {3} {4} [built]
@@ -16,6 +17,7 @@ Child
 Child
     Hash: 637b388d1abe7f9228e5
     Time: Xms
+    Built at: Thu Jan 01 1970 00:00:00 GMT
        [0] (webpack)/test/statsCases/scope-hoisting-multi/common_lazy_shared.js 25 bytes {0} {1} {2} [built]
        [1] (webpack)/test/statsCases/scope-hoisting-multi/vendor.js 25 bytes {5} [built]
            ModuleConcatenation (inner): module is an entrypoint

--- a/test/statsCases/warnings-uglifyjs/expected.txt
+++ b/test/statsCases/warnings-uglifyjs/expected.txt
@@ -1,12 +1,11 @@
-Hash: 4beee256fa6b8f69eae8
+Hash: 2c9851f0ea4c9778e64a
 Time: Xms
 Built at: Thu Jan 01 1970 00:00:00 GMT
-    Asset     Size  Chunks             Chunk Names
-bundle.js  2.17 kB       0  [emitted]  main
-chunk    {0} bundle.js (main) 1.04 kB [entry] [rendered]
-   [0] (webpack)/buildin/module.js 495 bytes {0} [built]
+    Asset    Size  Chunks             Chunk Names
+bundle.js  2.1 kB       0  [emitted]  main
+   [0] (webpack)/test/statsCases/warnings-uglifyjs/index.js 299 bytes {0} [built]
    [1] (webpack)/test/statsCases/warnings-uglifyjs/a.js 249 bytes {0} [built]
-   [2] (webpack)/test/statsCases/warnings-uglifyjs/index.js 299 bytes {0} [built]
+   [2] (webpack)/buildin/module.js 495 bytes {0} [built]
 
 WARNING in bundle.js from UglifyJs
 Dropping unused function someUnRemoteUsedFunction1 [./a.js:3,0]


### PR DESCRIPTION
Related to <https://github.com/webpack/webpack/pull/5026>

Fixed the probably outdated tests after the merge from `webpack/webpack`.

Tests should all be passing  now.